### PR TITLE
ci: fix APK build pipeline

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,30 +1,39 @@
+name: "Build & Release"
+
 on:
   push:
     branches:
       - main
-      - master
-name: "Build & Release"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
 jobs:
   build:
     name: Build & Release
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
-          java-version: '12'
+          java-version: '17'
+
       - uses: subosito/flutter-action@v2
         with:
           channel: 'stable'
-          architecture: x64
+          cache: true
+
+      - run: flutter pub get
 
       - run: flutter build apk --release
-      
+
       - name: Push to Releases
         uses: ncipollo/release-action@v1
         with:
-          artifacts: "build/app/outputs/apk/release/*"
+          artifacts: "build/app/outputs/flutter-apk/*.apk"
           tag: v1.0.${{ github.run_number }}
-          token: ${{ secrets.TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          allowUpdates: true


### PR DESCRIPTION
- Bump JDK 12 -> 17 (required by Gradle 8.14 / modern AGP)
- Fix artifact path to build/app/outputs/flutter-apk/*.apk
- Use built-in GITHUB_TOKEN with contents:write instead of custom TOKEN
- Update actions: checkout@v4, setup-java@v4; add Flutter caching
- Add workflow_dispatch and flutter pub get; allowUpdates on release